### PR TITLE
Splash, fixed #4

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -60,3 +60,21 @@ function showIcon(tab_id) {
 	icon_path = radioEnabled ? "img/on.png" : "img/off.png";
 	chrome.pageAction.setIcon({tabId: tab_id, path:icon_path});
 }
+
+// Check whether new version is installed
+chrome.runtime.onInstalled.addListener(function(details){
+	// direct to welcome page
+
+    if(details.reason == "install"){
+        console.log("First time install, show website");
+		// new tab with install page
+		chrome.tabs.create({url: "http://www.richard-stanton.com/chrome-plugins/youtube-radio/radioinstall/"});
+    }else if(details.reason == "update"){
+        var thisVersion = chrome.runtime.getManifest().version;
+        console.log("Updated from " + details.previousVersion + " to " + thisVersion + "!");
+		// show if updating from 1.2, only for future versions >2.0.1
+		// if (details.previousVersion == "1.2") {
+			chrome.tabs.create({url: "http://www.richard-stanton.com/chrome-plugins/youtube-radio/radioinstall/"});
+		// }
+    }
+});

--- a/js/background.js
+++ b/js/background.js
@@ -72,9 +72,10 @@ chrome.runtime.onInstalled.addListener(function(details){
     }else if(details.reason == "update"){
         var thisVersion = chrome.runtime.getManifest().version;
         console.log("Updated from " + details.previousVersion + " to " + thisVersion + "!");
-		// show if updating from 1.2, only for future versions >2.0.1
-		// if (details.previousVersion == "1.2") {
+		
+		// show if updating from 1.2
+		if (details.previousVersion == "1.2") {
 			chrome.tabs.create({url: "http://www.richard-stanton.com/chrome-plugins/youtube-radio/radioinstall/"});
-		// }
+		}
     }
 });

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
     "name": "Radio Mode for YouTube™",
     "description": "Replace background YouTube™ videos with more efficient audio, for less distractions.",
     "short_name": "YouTube™ Radio",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "author": "Richard Stanton",
   
 	"minimum_chrome_version": "34",

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
     "name": "Radio Mode for YouTube™",
     "description": "Replace background YouTube™ videos with more efficient audio, for less distractions.",
     "short_name": "YouTube™ Radio",
-    "version": "2.0",
+    "version": "2.0.1",
     "author": "Richard Stanton",
   
 	"minimum_chrome_version": "34",


### PR DESCRIPTION
Splash screen added for new users installing, and older uses updating from pre ver2.0.

Change in manifest permissions will cause plugins to re-activate. Users will have to re-activate, probably lose some users.
